### PR TITLE
Fix TimeMachine Request

### DIFF
--- a/DarkSkyKit/Router.swift
+++ b/DarkSkyKit/Router.swift
@@ -17,7 +17,7 @@ enum Router: URLRequestConvertible {
         case .current(let c, let lat, let long):
             return "/forecast/\(c.token)/\(lat),\(long)"
         case .timeMachine(let c, let lat, let long, let date):
-            return "/forecast/\(c.token)/\(lat),\(long),\(date.timeIntervalSince1970)"
+            return "/forecast/\(c.token)/\(lat),\(long),\(Int(round(date.timeIntervalSince1970)))"
         }
     }
 


### PR DESCRIPTION
### Short description
> Fix timeMachine request in router because it was failing hard.

### Solution
> The request had decimals for the timestamp which caused a `Not Found` response from the DarkSky API.

### Implementation
> Rounding the timestamp and then cast it into an `Int`.

- [x] Round the timestamp
- [x] Cast the rounded timestamp as an `Int`

### GIF
> ![](https://media3.giphy.com/media/8ggVeQfq7X33y/giphy.gif)