### PR TITLE
Fixed typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Fetch current weather conditions based on a given location.
 ```swift
 forecastClient.current(latitude: 0.34565, longitude: 1.64559) { result in
   switch result {
-    case .Success(let forecast):
+    case .success(let forecast):
       // Manage weather data using the Forecast model. Ex:
       if let current = forecast.currently {
         let t = current.temperature
       }
-    case .Failure(let error):
+    case .failure(let error):
       // Manage error case
   }
 }


### PR DESCRIPTION
There is .Success and  .Failure insted of .sucess and .failure :)

**Issue:** [Link](https://github.com/carambalabs/XXXX/issues/YYY)

### Short description
> Fixed typo in example

### Solution
> The case of result were .success and .failure but there was .Sucess and .Failure
### Implementation
> Simply change the cases

### GIF
> Find a descriptive GIF for your PR. Because we :heart: fun at Carambalabs.